### PR TITLE
Fixing wrong name shown in launcher and activity title

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         <activity
             android:name=".ActivityMain"
             android:configChanges="orientation|screenSize"
-            android:label="Main"
+            android:label="NetGuard"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,7 +16,7 @@ Ció è causato da alcuni bug contenuti in Android, o in programmi forniti dal p
 
     <string name="setting_whitelist_wifi">Blocca Wi-Fi di default</string>
     <string name="setting_whitelist_other">Blocca rete dati di default</string>
-    <string name="setting_unused">Default allow when screen is on</string>
+    <string name="setting_unused">Permetti di default quando lo schermo è acceso</string>
     <string name="setting_whitelist_roaming">Blocca roaming di default</string>
     <string name="setting_system">Gestisci applicazioni di sistema</string>
     <string name="setting_dark">Usa il tema scuro</string>


### PR DESCRIPTION
Otherwise both the name of the app in the launcher and in the main activity title would be "Main"