### PR TITLE
Update German strings.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,15 +16,15 @@ Das wird von Fehlern in Android oder in Software vom Hersteller verursacht. Bitt
     <string name="setting_whitelist_other">Mobilfunk standardmäßig blockieren</string>
     <string name="setting_unused">Standardmäßig erlauben, wenn Bildschirm an</string>
     <string name="setting_whitelist_roaming">Roaming standardmäßig blockieren</string>
-    <string name="setting_metered">Handle metered Wi-Fi networks</string>
+    <string name="setting_metered">Gemessenes WLAN-Netzwerk handhaben</string>
     <string name="setting_system">System-Apps anzeigen</string>
     <string name="setting_dark">Dunkles Thema verwenden</string>
     <string name="setting_export">Einstellungen exportieren</string>
     <string name="setting_import">Einstellungen importieren</string>
-    <string name="setting_technical">Technical information</string>
+    <string name="setting_technical">Technische information</string>
 
     <string name="summary_system">Regeln für System-Apps definieren (für Experten)</string>
-    <string name="summary_metered">Apply mobile network rules to metered (paid, tethered) Wi-Fi networks</string>
+    <string name="summary_metered">Mobilfunk-Regeln gemessenen (bezahlten, tethered) WLAN-Netzwerken anwenden</string>
 
     <string name="msg_sure">Sind Sie sicher?</string>
     <string name="msg_started">Regeln werden angewendet</string>


### PR DESCRIPTION
Wi-Fi is a trademark, a syndicate which certified wireless interfaces. An art-term. Sometimes WiFi will be used insted of WLAN in German, but for me here WLAN makes more sense.