### PR TITLE
Misc compatibility settings

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -216,9 +216,15 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         screen.findPreference("vpn4").setTitle(getString(R.string.setting_vpn4, prefs.getString("vpn4", "10.1.10.1")));
         screen.findPreference("vpn6").setTitle(getString(R.string.setting_vpn6, prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1")));
         EditTextPreference pref_dns = (EditTextPreference) screen.findPreference("dns");
-        List<String> def_dns = Util.getDefaultDNS(this);
-        pref_dns.getEditText().setHint(def_dns.get(0));
-        pref_dns.setTitle(getString(R.string.setting_dns, prefs.getString("dns", def_dns.get(0))));
+        boolean ignoresysdns = prefs.getBoolean("ignoresysdns", false);
+        if (ignoresysdns) {
+            pref_dns.getEditText().setHint("8.8.8.8");
+            pref_dns.setTitle(getString(R.string.setting_dns, prefs.getString("dns", "8.8.8.8")));
+        } else {
+            List<String> def_dns = Util.getDefaultDNS(this);
+            pref_dns.getEditText().setHint(def_dns.get(0));
+            pref_dns.setTitle(getString(R.string.setting_dns, prefs.getString("dns", def_dns.get(0))));
+        }
 
         // PCAP parameters
         screen.findPreference("pcap_record_size").setTitle(getString(R.string.setting_pcap_record_size, prefs.getString("pcap_record_size", "64")));
@@ -601,6 +607,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
         } else if ("dns".equals(name)) {
             String dns = prefs.getString("dns", null);
+            boolean ignoresysdns = prefs.getBoolean("ignoresysdns", false);
             try {
                 checkAddress(dns);
             } catch (Throwable ex) {
@@ -609,8 +616,12 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     Toast.makeText(ActivitySettings.this, ex.toString(), Toast.LENGTH_LONG).show();
             }
             SinkholeService.reload("changed " + name, this);
-            getPreferenceScreen().findPreference(name).setTitle(
-                    getString(R.string.setting_dns, prefs.getString("dns", Util.getDefaultDNS(this).get(0))));
+            if (ignoresysdns)
+                getPreferenceScreen().findPreference(name).setTitle(
+                        getString(R.string.setting_dns, prefs.getString("dns", "8.8.8.8")));
+            else
+                getPreferenceScreen().findPreference(name).setTitle(
+                        getString(R.string.setting_dns, prefs.getString("dns", Util.getDefaultDNS(this).get(0))));
         } else if ("pcap_record_size".equals(name) || "pcap_file_size".equals(name)) {
             if ("pcap_record_size".equals(name))
                 getPreferenceScreen().findPreference(name).setTitle(getString(R.string.setting_pcap_record_size, prefs.getString(name, "64")));

--- a/app/src/main/java/eu/faircode/netguard/SinkholeService.java
+++ b/app/src/main/java/eu/faircode/netguard/SinkholeService.java
@@ -950,25 +950,34 @@ public class SinkholeService extends VpnService implements SharedPreferences.OnS
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         List<String> sysDns = Util.getDefaultDNS(context);
         String vpnDns = prefs.getString("dns", null);
+        boolean ignoresysdns = prefs.getBoolean("ignoresysdns", false);
         Log.i(TAG, "DNS system=" + TextUtils.join(",", sysDns) + " VPN=" + vpnDns);
 
-        if (vpnDns != null)
+        if (vpnDns != null) {
             try {
                 InetAddress dns = InetAddress.getByName(vpnDns);
                 if (!(dns.isLoopbackAddress() || dns.isAnyLocalAddress()))
                     listDns.add(dns);
             } catch (Throwable ignored) {
             }
+        } else
+            if (ignoresysdns)
+                try {
+                    InetAddress dns = InetAddress.getByName("8.8.8.8");
+                    if (!(dns.isLoopbackAddress() || dns.isAnyLocalAddress()))
+                        listDns.add(dns);
+                } catch (Throwable ignored) {
+                }
 
-        for (String def_dns : sysDns)
-            try {
-                InetAddress ddns = InetAddress.getByName(def_dns);
-                if (!listDns.contains(ddns) &&
-                        !(ddns.isLoopbackAddress() || ddns.isAnyLocalAddress()))
-                    listDns.add(ddns);
-            } catch (Throwable ignored) {
-            }
-
+        if (!ignoresysdns)
+            for (String def_dns : sysDns)
+                try {
+                    InetAddress ddns = InetAddress.getByName(def_dns);
+                    if (!listDns.contains(ddns) &&
+                            !(ddns.isLoopbackAddress() || ddns.isAnyLocalAddress()))
+                        listDns.add(ddns);
+                } catch (Throwable ignored) {
+                }
         return listDns;
     }
 

--- a/app/src/main/java/eu/faircode/netguard/SinkholeService.java
+++ b/app/src/main/java/eu/faircode/netguard/SinkholeService.java
@@ -80,6 +80,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.net.Inet4Address;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.text.DateFormat;
@@ -986,6 +987,7 @@ public class SinkholeService extends VpnService implements SharedPreferences.OnS
         boolean tethering = prefs.getBoolean("tethering", false);
         boolean filter = prefs.getBoolean("filter", false);
         boolean system = prefs.getBoolean("manage_system", false);
+        boolean routedns = prefs.getBoolean("routedns", false);
 
         // Build VPN service
         Builder builder = new Builder();
@@ -1002,6 +1004,12 @@ public class SinkholeService extends VpnService implements SharedPreferences.OnS
             for (InetAddress dns : getDns(SinkholeService.this)) {
                 Log.i(TAG, "dns=" + dns);
                 builder.addDnsServer(dns);
+
+                if (routedns)
+                    if (dns instanceof Inet4Address)
+                        builder.addRoute(dns, 32);
+                    else
+                        builder.addRoute(dns, 128);
             }
 
         if (tethering) {

--- a/app/src/main/java/eu/faircode/netguard/SinkholeService.java
+++ b/app/src/main/java/eu/faircode/netguard/SinkholeService.java
@@ -395,6 +395,7 @@ public class SinkholeService extends VpnService implements SharedPreferences.OnS
 
         private void reload() {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(SinkholeService.this);
+            boolean forcerestart = prefs.getBoolean("forcerestart", false);
 
             if (state != State.enforcing) {
                 if (state != State.none) {
@@ -410,7 +411,7 @@ public class SinkholeService extends VpnService implements SharedPreferences.OnS
             List<Rule> listAllowed = getAllowedRules(listRule);
             SinkholeService.Builder builder = getBuilder(listAllowed, listRule);
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
+            if ((Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) || forcerestart) {
                 last_builder = builder;
                 Log.i(TAG, "Legacy restart");
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@ however it is impossible to guarantee NetGuard will work correctly on every devi
     <string name="setting_dns">VPN DNS: %s</string>
     <string name="setting_pcap_record_size">PCAP record size: %s B</string>
     <string name="setting_pcap_file_size">PCAP max. file size: %s MB</string>
+    <string name="setting_forcerestart" translatable="false">Force full VPN restart on reload</string>
 
     <string name="setting_stats_category">Speed notification</string>
     <string name="setting_stats">Show speed notification</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@ however it is impossible to guarantee NetGuard will work correctly on every devi
     <string name="setting_pcap_file_size">PCAP max. file size: %s MB</string>
     <string name="setting_forcerestart" translatable="false">Force full VPN restart on reload</string>
     <string name="setting_routedns" translatable="false">Force route DNS into VPN</string>
+    <string name="setting_ignoresysdns" translatable="false">Use only VPN DNS, ignore system</string>
 
     <string name="setting_stats_category">Speed notification</string>
     <string name="setting_stats">Show speed notification</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@ however it is impossible to guarantee NetGuard will work correctly on every devi
     <string name="setting_pcap_record_size">PCAP record size: %s B</string>
     <string name="setting_pcap_file_size">PCAP max. file size: %s MB</string>
     <string name="setting_forcerestart" translatable="false">Force full VPN restart on reload</string>
+    <string name="setting_routedns" translatable="false">Force route DNS into VPN</string>
 
     <string name="setting_stats_category">Speed notification</string>
     <string name="setting_stats">Show speed notification</string>

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -221,6 +221,11 @@
         <Preference
             android:key="show_resolved"
             android:title="@string/setting_show_resolved" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="forcerestart"
+            android:title="@string/setting_forcerestart" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -231,6 +231,11 @@
             android:dependency="filter"
             android:key="routedns"
             android:title="@string/setting_routedns" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="ignoresysdns"
+            android:title="@string/setting_ignoresysdns" />
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -247,4 +252,3 @@
             android:title="@string/setting_technical_subscription" />
     </PreferenceCategory>
 </PreferenceScreen>
-

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -226,6 +226,11 @@
             android:dependency="filter"
             android:key="forcerestart"
             android:title="@string/setting_forcerestart" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="routedns"
+            android:title="@string/setting_routedns" />
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -242,3 +247,4 @@
             android:title="@string/setting_technical_subscription" />
     </PreferenceCategory>
 </PreferenceScreen>
+

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -226,6 +226,11 @@
             android:dependency="filter"
             android:key="forcerestart"
             android:title="@string/setting_forcerestart" />
+        <eu.faircode.netguard.SwitchPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="routedns"
+            android:title="@string/setting_routedns" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -231,6 +231,11 @@
             android:dependency="filter"
             android:key="routedns"
             android:title="@string/setting_routedns" />
+        <eu.faircode.netguard.SwitchPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="ignoresysdns"
+            android:title="@string/setting_ignoresysdns" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -221,6 +221,11 @@
         <Preference
             android:key="show_resolved"
             android:title="@string/setting_show_resolved" />
+        <eu.faircode.netguard.SwitchPreference
+            android:defaultValue="false"
+            android:dependency="filter"
+            android:key="forcerestart"
+            android:title="@string/setting_forcerestart" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
In debugging for now:
* forcerestart - fix #345 for ROMs that bypass the VPN for DNS calls on switch to mobile (eg. Xperia 5.1.1) by using the same reload method (destroy VPN) as used already for SDK<22
* routedns - https://github.com/M66B/NetGuard/commit/7673dceb8df28d76bc0ba5b085b41249d26e8b82 with a toggle ([might help some Samsung users](https://github.com/schwabe/ics-openvpn/blob/3ebdb6482f3bab9423436e6b208963d5d7c07656/main/src/main/java/de/blinkt/openvpn/core/OpenVPNService.java#L590))
* ignoresysdns - create VPN without system DNS servers, if no server is set up in app then Google's 8.8.8.8 is used