### PR TITLE
Don't bother with routes if no filtering

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1000,7 +1000,7 @@ public class ServiceSinkhole extends VpnService implements SharedPreferences.OnS
                 builder.addDnsServer(dns);
             }
 
-        if (tethering) {
+        if (tethering && filter) {
             // USB Tethering 192.168.42.x
             // Wi-Fi Tethering 192.168.43.x
             // https://en.wikipedia.org/wiki/IPv4#Special-use_addresses


### PR DESCRIPTION
Not sure if better like this or to nest tethering in filter directly, like:
```
if (filter) {
    ...
    if (tethering) {
    }
}
```

Does the VPN work without any routes? I see it gets no DNS anyway.