### PR TITLE
German translation title_pro_all

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -214,7 +214,7 @@
   <string name="title_pro_notify">Benachrichtigung über neue App</string>
   <string name="title_pro_speed">Netzwerkgeschwindigkeitsgraphbenachrichtigung</string>
   <string name="title_pro_theme">Aussehen (Design, Farben)</string>
-  <string name="title_pro_all">Alles über Pro-Funktionen</string>
+  <string name="title_pro_all">Alle oben erwähnten Pro-Funktionen</string>
   <string name="title_pro_dev">Entwicklung unterstützen</string>
   <string name="title_pro_buy">Kaufen</string>
   <string name="title_pro_bought">Aktiviert</string>


### PR DESCRIPTION
The former translation read "All about pro features", the new one means approximately "All the above mentioned pro features".