### PR TITLE
ICMP management Fix

### DIFF
--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -199,7 +199,7 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1get_1stats(
     struct ng_session *s = ctx->ng_session;
     while (s != NULL) {
         if (s->protocol == IPPROTO_ICMP || s->protocol == IPPROTO_ICMPV6) {
-            if (!s->icmp.stop)
+            if (s->icmp.stop <= 0)
                 jcount[0]++;
         } else if (s->protocol == IPPROTO_UDP) {
             if (s->udp.state == UDP_ACTIVE)

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -119,7 +119,7 @@ struct icmp_session {
 
     uint16_t id;
 
-    uint8_t stop;
+    int8_t stop; //three state: 0:false, 1:true, -1:answered
 };
 
 #define UDP_ACTIVE 0
@@ -265,6 +265,7 @@ struct dns_header {
     uint16_t aa :1; // authoritive answer
     uint16_t opcode :4; // purpose of message
     uint16_t qr :1; // query/response flag
+    //next byte (8 bit)
     uint16_t rcode :4; // response code
     uint16_t cd :1; // checking disabled
     uint16_t ad :1; // authenticated data
@@ -276,6 +277,7 @@ struct dns_header {
     uint16_t aa :1; // authoritive answer
     uint16_t tc :1; // truncated message
     uint16_t rd :1; // recursion desired
+    //next byte (8 bit)
     uint16_t ra :1; // recursion available
     uint16_t z :1; // its z! reserved
     uint16_t ad :1; // authenticated data

--- a/app/src/main/jni/netguard/session.c
+++ b/app/src/main/jni/netguard/session.c
@@ -99,7 +99,7 @@ void *handle_events(void *a) {
         struct ng_session *s = args->ctx->ng_session;
         while (s != NULL) {
             if (s->protocol == IPPROTO_ICMP || s->protocol == IPPROTO_ICMPV6) {
-                if (!s->icmp.stop)
+                if (s->icmp.stop <= 0)
                     isessions++;
             } else if (s->protocol == IPPROTO_UDP) {
                 if (s->udp.state == UDP_ACTIVE)
@@ -126,7 +126,7 @@ void *handle_events(void *a) {
                 int del = 0;
                 if (s->protocol == IPPROTO_ICMP || s->protocol == IPPROTO_ICMPV6) {
                     del = check_icmp_session(args, s, sessions, maxsessions);
-                    if (!s->icmp.stop && !del) {
+                    if (s->icmp.stop == 0 && !del) {
                         int stimeout = s->icmp.time +
                                        get_icmp_timeout(&s->icmp, sessions, maxsessions) - now + 1;
                         if (stimeout > 0 && stimeout < timeout)
@@ -282,7 +282,7 @@ void check_allowed(const struct arguments *args) {
     struct ng_session *s = args->ctx->ng_session;
     while (s != NULL) {
         if (s->protocol == IPPROTO_ICMP || s->protocol == IPPROTO_ICMPV6) {
-            if (!s->icmp.stop) {
+            if (s->icmp.stop <= 0) {
                 if (s->icmp.version == 4) {
                     inet_ntop(AF_INET, &s->icmp.saddr.ip4, source, sizeof(source));
                     inet_ntop(AF_INET, &s->icmp.daddr.ip4, dest, sizeof(dest));


### PR DESCRIPTION
the first ICMP session that gets created did never stop, when there comes unstop other requests for an other port/id after the first all others will fail since the requestor checks the ICMP id that it last used but it did got from NetGuard the first id used for that site.

we did find the bug using Apps whichs only propose are to ping and only the first ping got ever answered