### PR TITLE
Fix building on AS 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {


### PR DESCRIPTION
...else `Gradle sync failed: Could not find any version that matches com.android.tools.build:gradle:3.0.+`