### PR TITLE
Fix condition for filtering local DNS servers

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1105,7 +1105,7 @@ public class ServiceSinkhole extends VpnService implements SharedPreferences.OnS
         // Remove local DNS servers when not routing LAN
         boolean lan = prefs.getBoolean("lan", false);
         boolean use_hosts = prefs.getBoolean("filter", false) && prefs.getBoolean("use_hosts", false);
-        if (lan && use_hosts) {
+        if (!lan && use_hosts) {
             List<InetAddress> listLocal = new ArrayList<>();
             try {
                 Enumeration<NetworkInterface> nis = NetworkInterface.getNetworkInterfaces();


### PR DESCRIPTION
Previously local DNS servers were removed when LAN access was enabled.
Instead it should be the other way around. With LAN access one wants to use the local DNS servers.