### PR TITLE
AndroidManifest.xml: Enable backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
 
     <application
         android:name="ApplicationEx"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:appCategory="productivity"
         android:description="@string/app_description"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Having a backup of the rules configuration would be very useful in case of data loss.

Background:
As smartphones can easily be lost or get stolen or break, it is useful to have regular backups. I recommend to back up the smartphone at least once a month or even once per week. Prior to this change, NetGuard would not be backed up, i.e. in case of data loss and the user restoring a backup, both the NetGuard app and all its config would be missing.