### PR TITLE
increase BOOT_COMPLETED intent priority to 999

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,7 +211,7 @@
         <receiver
             android:name=".ReceiverAutostart"
             android:label="@string/app_name">
-            <intent-filter>
+            <intent-filter android:priority="999">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>


### PR DESCRIPTION
This is to increase the priority of Netguard being launched at startup.

The developer docs used to be a bit clearer on this, for some reason they removed the section about possible values from the intent filter overview page ( https://developer.android.com/guide/topics/manifest/intent-filter-element#priority )

But it can be derived from here:
https://developer.android.com/reference/android/content/IntentFilter.html#setPriority(int)
("Applications should use a value that is larger than SYSTEM_LOW_PRIORITY and smaller than SYSTEM_HIGH_PRIORITY ." )

Their values (SYSTEM_LOW_PRIORITY: -1000, SYSTEM_HIGH_PRIORITY: 1000) are listed here: 
https://developer.android.com/reference/android/content/IntentFilter.html#SYSTEM_HIGH_PRIORITY



