### PR TITLE
Set metered connection status on Android 10

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1250,6 +1250,10 @@ public class ServiceSinkhole extends VpnService implements SharedPreferences.OnS
         Builder builder = new Builder();
         builder.setSession(getString(R.string.app_name));
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            builder.setMetered(Util.isMeteredNetwork(this));
+        }
+
         // VPN address
         String vpn4 = prefs.getString("vpn4", "10.1.10.1");
         Log.i(TAG, "Using VPN4=" + vpn4);


### PR DESCRIPTION
This issue has been frustrating me for a while, so I finally decided to figure out what the problem was.  It seemed as if apps thought I was always on a mobile connection, even when on wifi.  This surfaced due to apps with settings like "only download when on wifi" that simply did not work as expected anymore, including getting automatic Play Store updates.  This made no sense, since everything correctly reported that I was on a wifi connection.

After some additional research, I discovered that "[VPN apps targeting Build.VERSION_CODES.Q or above will be considered metered by default.](https://developer.android.com/reference/android/net/VpnService.Builder#setMetered(boolean))"  Since I'm on Android 10, this seemed like the culprit.  After testing this fix, my connection is working properly again.

As I'm not very familiar with the code, I wasn't 100% sure if this would be sufficient to always update the value if the underlying connection changes, but in my limited testing it's working fine.