### PR TITLE
Easily show only disabled or without internet apps.

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -353,7 +353,8 @@ public class Rule {
                     if (all ||
                             ((rule.system ? show_system : show_user) &&
                                     (show_nointernet || rule.internet) &&
-                                    (show_disabled || rule.enabled))) {
+                                    (show_disabled || rule.enabled)) ||
+                        (!show_system && !show_user && ((show_disabled && !rule.enabled) || (show_nointernet && !rule.internet))) ) {
 
                         rule.wifi_default = (pre_wifi_blocked.containsKey(info.packageName) ? pre_wifi_blocked.get(info.packageName) : default_wifi);
                         rule.other_default = (pre_other_blocked.containsKey(info.packageName) ? pre_other_blocked.get(info.packageName) : default_other);


### PR DESCRIPTION
By selecting "Show disabled apps" and/or "Show apps without internet" and deselecting both "Show user apps" and "Show system apps", all the disabled and/or without internet apps are shown.  This is useful to quickly check the status of these apps - personally I set them all disabled.

With current 2.285 release, deselecting both "Show user apps" and "Show system apps" simply shows nothing.

Behaviour is unchanged compared to current 2.285 release if one or both of "Show user apps" and "Show system apps" is selected.