### PR TITLE
User preference to skip beta updates

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -319,8 +319,10 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
         pref_rcode.setTitle(getString(R.string.setting_rcode, prefs.getString("rcode", "3")));
 
-        if (Util.isPlayStoreInstall(this) || !Util.hasValidFingerprint(this))
+        if (Util.isPlayStoreInstall(this) || !Util.hasValidFingerprint(this)) {
             cat_options.removePreference(screen.findPreference("update_check"));
+            cat_options.removePreference(screen.findPreference("beta_release"));
+        }
 
         if (Util.isPlayStoreInstall(this)) {
             Log.i(TAG, "Play store install");

--- a/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
@@ -118,6 +118,7 @@ public class ReceiverAutostart extends BroadcastReceiver {
 
             if (Util.isPlayStoreInstall(context)) {
                 editor.remove("update_check");
+                editor.remove("beta_release");
                 editor.remove("use_hosts");
                 editor.remove("hosts_url");
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="setting_auto">Auto enable after %1$s minutes</string>
     <string name="setting_delay">Delay screen off %1$s minutes</string>
     <string name="setting_update">Check for updates</string>
+    <string name="setting_beta_release">Beta releases</string>
 
     <string name="setting_network_options">Network options</string>
     <string name="setting_subnet">Subnet routing</string>
@@ -155,6 +156,7 @@
     <string name="summary_auto">After disabling using the widget, automatically enable NetGuard again after the selected number of minutes (enter zero to disable this option)</string>
     <string name="summary_delay">After turning the screen off, keep screen on rules active for the selected number of minutes (enter zero to disable this option)</string>
     <string name="summary_update">Check for new releases on GitHub twice daily</string>
+    <string name="summary_beta_release">Notify for beta releases</string>
 
     <string name="summary_tethering">Depending on the Android version, tethering may work or may not work. Tethered traffic cannot be filtered.</string>
     <string name="summary_subnet">Enable subnet routing; might enable Wi-Fi calling, but might also trigger bugs in Android and increase battery usage</string>

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -70,6 +70,12 @@
                 android:key="update_check"
                 android:summary="@string/summary_update"
                 android:title="@string/setting_update" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:dependency="update_check"
+                android:key="beta_release"
+                android:summary="@string/summary_beta_release"
+                android:title="@string/setting_beta_release" />
         </PreferenceCategory>
     </PreferenceScreen>
 

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -70,6 +70,12 @@
                 android:key="update_check"
                 android:summary="@string/summary_update"
                 android:title="@string/setting_update" />
+            <eu.faircode.netguard.SwitchPreference
+                android:defaultValue="false"
+                android:dependency="update_check"
+                android:key="beta_release"
+                android:summary="@string/summary_beta_release"
+                android:title="@string/setting_beta_release" />
         </PreferenceCategory>
     </PreferenceScreen>
 


### PR DESCRIPTION
This PR adds a new user preference under Settings > Options to toggle notifying for beta release updates.
This option is turned off by default, and when off releases such as [2.330 beta](https://github.com/M66B/NetGuard/releases/tag/2.330) will not trigger a notification, helping those users that like to remain on stable versions.